### PR TITLE
:new: Using Openshift pro tier

### DIFF
--- a/.openshift-config.yaml
+++ b/.openshift-config.yaml
@@ -1,0 +1,307 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: votebot-dev-build-template
+parameters:
+- name: BOT_NAME
+  description: The Bot name
+  displayName: Bot Name
+  required: true
+  value: "votebot-dev"
+- name: SEND_EMAIL
+  description: Whether the bot should send emails or not; defaults to false
+  displayName: Send Email?
+  required: true
+  value: "true"
+- name: ESCO_USER_LIST
+  description: The list of votebot users that are part of the relay
+  displayName: ESCo User List
+  required: true
+- name: ESCO_USER_VOTE
+  description: The list of votebot users that are allowed to vote
+  displayName: ESCo User Vote List
+  required: true
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: ${BOT_NAME}
+    name: s2i-java-binary
+  spec:
+    dockerImageRepository: "docker.io/maoo/s2i-java-binary"
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: ${BOT_NAME}
+    name: ${BOT_NAME}
+  spec: {}
+  status:
+    dockerImageRepository: ""
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: ${BOT_NAME}
+    labels:
+      app: ${BOT_NAME}
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${BOT_NAME}:latest
+    postCommit: {}
+    resources: {}
+    runPolicy: Serial
+    source:
+      type: Binary
+      binary:
+    strategy:
+      type: Source
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: s2i-java-binary:latest
+    triggers: {}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: ${BOT_NAME}
+    name: ${BOT_NAME}
+  spec:
+    replicas: 1
+    selector:
+      app: ${BOT_NAME}
+      deploymentconfig: ${BOT_NAME}
+    strategy:
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: ${BOT_NAME}
+          deploymentconfig: ${BOT_NAME}
+      spec:
+        containers:
+        - image: ${BOT_NAME}:latest
+          imagePullPolicy: Always
+          name: ${BOT_NAME}
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: "/symphony/votebot/v1/proposal/1"
+              port: 8080
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          env:
+          - name: ESCO_USER_LIST
+            value: ${ESCO_USER_LIST}
+          - name: ESCO_USER_VOTE
+            value: ${ESCO_USER_VOTE}
+          - name: MAIL_SEND_EMAIL
+            value: ${SEND_EMAIL}
+          - name: RUN_FOLDER
+            value: "/opt/openshift"
+          - name: RUN_COMMAND
+            value: "/opt/openshift/bin/VoteBot"
+          - name: LOG4J_FILE
+            value: "/opt/openshift/log4j.properties"
+          - name: SESSION_AUTH
+            value: https://foundation-dev-api.symphony.com/sessionauth
+          - name: KEY_AUTH
+            value: https://foundation-dev-api.symphony.com/keyauth
+          - name: SYMPHONY_POD
+            value: https://foundation-dev.symphony.com/pod
+          - name: SYMPHONY_AGENT
+            value: https://foundation-dev.symphony.com/agent
+          - name: DOWNLOAD_HOST
+            valueFrom:
+              secretKeyRef:
+                name: symphony.foundation
+                key: download.host
+          - name: DOWNLOAD_PATH
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: certs.download.path
+          - name: DOWNLOAD_ITEMS
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: certs.download.items
+          - name: TRUSTSTORE_FILE
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: truststore.file
+          - name: TRUSTSTORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: truststore.password
+          - name: KEYSTORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: keystore.password
+          - name: CERTS
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: certs.path
+          - name: BOT_USER
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: bot.user
+          - name: BOT_DOMAIN
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: bot.domain
+          - name: MCP_NOTIFICATION_USER
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: mcp.notification.user
+          - name: MCP_NOTIFICATION_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: mcp.notification.password
+          - name: API_USER
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: api.user
+          - name: API_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: api.password
+          - name: MAIL_SMTP_HOST
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: smtp.host
+          - name: MAIL_SMTP_USER
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: smtp.user
+          - name: MAIL_SMTP_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: smtp.password
+          - name: MAIL_SMTP_AUTH
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: smtp.auth
+          - name: MAIL_VB_FROM
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: api.password
+          - name: MAIL_DISTRO_EMAIL
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: api.password
+          - name: MAIL_S3_PREFIX_INCOMING
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: mail.s3.prefix.incoming
+          - name: MAIL_S3_PREFIX_PROCESSED
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: mail.s3.prefix.processed
+          - name: S3_ENABLED
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: s3.enabled
+          - name: VB_S3_PREFIX_JSON
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: vb.s3.prefix.json
+          - name: S3_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: s3.access.key
+          - name: S3_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: s3.key.id
+          - name: S3_BUCKET
+            valueFrom:
+              secretKeyRef:
+                name: ${BOT_NAME}.certs
+                key: s3.bucket.name
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ${BOT_NAME}
+        from:
+          kind: ImageStreamTag
+          name: ${BOT_NAME}:latest
+      type: ImageChange
+  status: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    labels:
+      app: ${BOT_NAME}
+    name: ${BOT_NAME}
+  spec:
+    ports:
+    - name: healthcheck-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: ${BOT_NAME}
+      deploymentconfig: ${BOT_NAME}
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: ${BOT_NAME}
+    labels:
+      app: ${BOT_NAME}
+  spec:
+    to:
+      kind: Service
+      name: ${BOT_NAME}
+      weight: 100
+    port:
+      targetPort: healthcheck-tcp
+    wildcardPolicy: None

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@
 # under the License.
 #
 
-after_success: "if [[ \"$TRAVIS_PULL_REQUEST\" = \"false\" && $TRAVIS_BRANCH =~ master ]]; then curl -s https://raw.githubusercontent.com/symphonyoss/contrib-toolbox/master/scripts/oc-deploy.sh | bash ; fi"
+after_success: if [[ "$TRAVIS_PULL_REQUEST" = "false" ]]; then curl -s https://raw.githubusercontent.com/symphonyoss/contrib-toolbox/master/scripts/oc-deploy.sh | bash -s -- ${TRAVIS_BRANCH}; fi
 
 language: java
 
@@ -33,6 +33,12 @@ jdk:
 
 env:
   global:
-   # Used by oc-deploy.sh for CD
-   - OC_BINARY_ARCHIVE=vote-bot-service/target/vote-bot-service-0.9.0-SNAPSHOT-appassembler.zip
-   - OC_BUILD_CONFIG_NAME=votebot-prod
+    # Used by oc-deploy.sh for CD
+    - OC_BUILD_CONFIG_NAME_DEVELOP=votebot-dev
+    - OC_PROJECT_NAME_DEVELOP=ssf-dev
+    - OC_BUILD_CONFIG_NAME_MASTER=votebot-prod
+    - OC_PROJECT_NAME_MASTER=ssf-prod
+    - OC_BINARY_FOLDER="vote-bot-service/target/oc"
+    - OC_ENDPOINT="https://api.pro-us-east-1.openshift.com"
+    # ESCO_USER_LIST and ESCO_USER_VOTE (for dev and prod) are defined via Travis Settings and set by after-build-success.sh script
+    - OC_TEMPLATE_PROCESS_ARGS="-p BOT_NAME=$OC_BUILD_CONFIG_NAME -p ESCO_USER_LIST=$ESCO_USER_LIST -p ESCO_USER_VOTE=$ESCO_USER_VOTE"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Votebot Watcher](https://hv0dbm9dsd.execute-api.us-east-1.amazonaws.com/Prod/votebot-badge)](https://foundation.symphony.com)
+[![Votebot Prod Watcher](https://hv0dbm9dsd.execute-api.us-east-1.amazonaws.com/Prod/votebot-badge)](https://foundation.symphony.com)
+[![Votebot Dev Watcher](https://hv0dbm9dsd.execute-api.us-east-1.amazonaws.com/Prod/votebot-dev-badge)](https://foundation.symphony.com)
 
 The bot provides vote capabilities on proposals amongst a defined list of users over a relay chat.
 
@@ -8,29 +9,36 @@ Type `mvn package`.
 
 When the build completes, the ZIP file containing all bot logic can be found at `vote-bot-service/target/vote-bot-service-0.9.0-SNAPSHOT-appassembler.zip`.
 
-# Deploy to Openshift
+## Openshift
 
-First of all, select which environment/build to target by setting these environment variables:
-
-```
-export OC_PROJECT=botfarm
-# Choose between votebot-dev and votebot-prod
-export OC_DEPLOY=votebot-dev
-```
-
-1. [Install Openshift commandline](https://docs.openshift.org/latest/cli_reference/get_started_cli.html) tool `oc`
-2. Authenticate against Openshift Online instance of the Symphony Software Foundation using `oc login https://api.starter-us-east-1.openshift.com --token=$OC_TOKEN` ; the `OC_TOKEN` can be requested to Foundation Staff
-3. Use Openshift project using `oc project $OC_PROJECT`
-4. Checkout this project, `cd` into the root folder and build the project with `mvn package`
-5. Unzip the package being created using `unzip vote-bot-service/target/vote-bot-service-0.9.0-SNAPSHOT-appassembler.zip -d vote-bot-service/target/oc`
-6. Deploy the archive created using `oc start-build $OC_DEPLOY --from-dir=vote-bot-service/target/oc/vote-bot-service-0.9.0-SNAPSHOT/ --wait=true -n $OC_PROJECT`
-
-# Reset Openshift environment
 In order to run these commands you need to have access to the Openshift YAML definitions, which are managed by Foundation Staff.
 
-1. Delete all existing Openshift resources - `oc delete imagestream $OC_DEPLOY; oc delete buildconfig $OC_DEPLOY; oc delete dc $OC_DEPLOY; oc delete svc $OC_DEPLOY; oc delete route $OC_DEPLOY; oc delete secret $OC_DEPLOY.certs`
-2. Create Openshift secrets - `oc process -f ./secrets/$OC_DEPLOY.yaml | oc create -f -`
-3. Create other Openshift resources - `oc process -f ./builds/$OC_DEPLOY-build-template.yaml | oc create -f -`
+### Deploy to Openshift
+
+```
+. ./env-dev.sh
+curl -s https://raw.githubusercontent.com/symphonyoss/contrib-toolbox/master/scripts/oc-deploy.sh | bash
+```
+
+Make sure the following vars are included in `env-dev.sh`.
+```
+export OC_TOKEN=<your oc token>
+export OC_PROJECT=botfarm
+export OC_BINARY_FOLDER="vote-bot-service/target/oc"
+# Choose between votebot-dev or votebot-prod
+export OC_BUILD_CONFIG_NAME="votebot-dev"
+export OC_ENDPOINT="https://api.pro-us-east-1.openshift.com"
+export OC_PROJECT_NAME="ssf-dev"
+export ESCO_USER_VOTE=""
+export ESCO_USER_LIST=""
+export OC_TEMPLATE_PROCESS_ARGS="-p ESCO_USER_LIST=$ESCO_USER_LIST -p ESCO_USER_VOTE=$ESCO_USER_VOTE"
+```
+
+When configuring the environment variables via Travis CI settings, make sure to escape ' ', '(' and ')' chars, adding a '\' before.
+
+### Reset Openshift environment
+
+To delete all existing Openshift resources, simply invoke `oc delete all -l app=votebot-dev` (secrets, which are managed by Foundation staff, will not be removed)
 
 ### PROPOSAL
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Votebot Prod Watcher](https://hv0dbm9dsd.execute-api.us-east-1.amazonaws.com/Prod/votebot-badge)](https://foundation.symphony.com)
-[![Votebot Dev Watcher](https://hv0dbm9dsd.execute-api.us-east-1.amazonaws.com/Prod/votebot-dev-badge)](https://foundation.symphony.com)
+[![Vote Bot Prod Log Watcher](https://hv0dbm9dsd.execute-api.us-east-1.amazonaws.com/Prod/badge?oc_bot_name=votebot-prod&oc_project_name=ssf-prod)](https://foundation.symphony.com)
+[![Vote Bot Dev Log Watcher](https://hv0dbm9dsd.execute-api.us-east-1.amazonaws.com/Prod/badge?oc_bot_name=votebot-dev&oc_project_name=ssf-dev)](https://foundation-dev.symphony.com)
 
 The bot provides vote capabilities on proposals amongst a defined list of users over a relay chat.
 


### PR DESCRIPTION
**DO NOT MERGE THIS PR UNTIL REVIEW IS COMPLETED!**

The votebot is now deployed on the Foundation OpenShift Pro tier, which provides
- a `dev` project to host the bots in development stage (in this case, the `develop` branch, running against `foundation-dev.symphony.com` pod; votebot-dev is currently up and running and the [`README.md`](https://github.com/maoo/vote-bot/tree/oc-pro-tier) shows a green badge
- a `prod` project to host the bots in production stage (typically using `master` branch code); votebot-prod is currently deployed on another infrastructure and will be migrated on Wednesday 23 August (around 10am GMT); for this reason, the badge reported on the [`README.md`](https://github.com/maoo/vote-bot/tree/oc-pro-tier) returns an error.

The `ESCO_USER_LIST` and `ESCO_USER_VOTE` lists are expanded for `dev` and `prod` environments and are managed via Travis Settings, as shown in the screenshot below.

<img width="1088" alt="screen shot 2017-08-21 at 19 51 12" src="https://user-images.githubusercontent.com/327285/29531778-4b3503a8-86aa-11e7-9656-18d4711caa19.png">

The `OC_TOKEN` will have to be updated (by the Foundation Staff) as soon as this PR is merged.