### PR TITLE
Expose HealthCheck JMX MBean for remote bot monitoring

### DIFF
--- a/.openshift-config.yaml
+++ b/.openshift-config.yaml
@@ -96,16 +96,26 @@ objects:
           name: ${BOT_NAME}
           ports:
           - containerPort: 8080
+            name: jetty
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
             protocol: TCP
           readinessProbe:
             httpGet:
-              path: "/symphony/votebot/v1/proposal/1"
-              port: 8080
+              path: /jolokia/exec/org.symphonyoss.client:type=ClientCheckMBean/isUp
+              port: 8778
+          livenessProbe:
+            httpGet:
+              path: /jolokia/exec/org.symphonyoss.client:type=ClientCheckMBean/isUp
+              port: 8778
             initialDelaySeconds: 15
             timeoutSeconds: 1
           resources: {}
           terminationMessagePath: /dev/termination-log
           env:
+          - name: JOLOKIA_HOST
+            value: "*"
           - name: ESCO_USER_LIST
             valueFrom:
               secretKeyRef:
@@ -281,35 +291,26 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    annotations:
-      openshift.io/generated-by: OpenShiftNewApp
     labels:
       app: ${BOT_NAME}
-    name: ${BOT_NAME}
+    name: votebot-jolokia
   spec:
-    ports:
-    - name: healthcheck-tcp
-      port: 8080
-      protocol: TCP
-      targetPort: 8080
+    type: NodePort
     selector:
       app: ${BOT_NAME}
-      deploymentconfig: ${BOT_NAME}
-    sessionAffinity: None
-    type: ClusterIP
-  status:
-    loadBalancer: {}
+    ports:
+    - name: ${BOT_NAME}-jolokia-port
+      nodePort: 30778
+      port: 8778
+      protocol: TCP
+      targetPort: 8778
 - apiVersion: v1
   kind: Route
   metadata:
-    name: ${BOT_NAME}
     labels:
       app: ${BOT_NAME}
+    name: ${BOT_NAME}-jolokia
   spec:
     to:
       kind: Service
-      name: ${BOT_NAME}
-      weight: 100
-    port:
-      targetPort: healthcheck-tcp
-    wildcardPolicy: None
+      name: votebot-jolokia

--- a/.openshift-config.yaml
+++ b/.openshift-config.yaml
@@ -23,6 +23,11 @@ parameters:
   displayName: Symphony Pod host
   required: true
   # value: "foundation-dev.symphony.com"
+# Must be within 30000-32767 range - read more on https://docs.openshift.com/container-platform/latest/dev_guide/expose_service/expose_internal_ip_nodeport.html
+- name: JOLOKIA_NODE_PORT
+  description: The port used to expose the Jolokia service
+  displayName: The Jolokia external port
+  required: true
 objects:
 - apiVersion: v1
   kind: ImageStream
@@ -300,7 +305,7 @@ objects:
       app: ${BOT_NAME}
     ports:
     - name: ${BOT_NAME}-jolokia-port
-      nodePort: 30778
+      nodePort: ${JOLOKIA_NODE_PORT}
       port: 8778
       protocol: TCP
       targetPort: 8778

--- a/after-success.sh
+++ b/after-success.sh
@@ -21,6 +21,9 @@ elif [[ $BRANCH_NAME =~ develop ]]; then
     export BOT_NAME="votebot-dev"
     export OC_PROJECT_NAME="ssf-dev"
     export JOLOKIA_NODE_PORT=30011
+else
+	echo "Skipping deployment for branch $BRANCH_NAME"
+	exit 0
 fi
 
 export OC_BINARY_FOLDER="vote-bot-service/target/oc"

--- a/after-success.sh
+++ b/after-success.sh
@@ -28,7 +28,7 @@ fi
 
 export OC_BINARY_FOLDER="vote-bot-service/target/oc"
 export OC_ENDPOINT="https://api.pro-us-east-1.openshift.com"
-export OC_TEMPLATE_PROCESS_ARGS="BOT_NAME,SYMPHONY_POD_HOST,SYMPHONY_API_HOST"
+export OC_TEMPLATE_PROCESS_ARGS="BOT_NAME,SYMPHONY_POD_HOST,SYMPHONY_API_HOST,JOLOKIA_NODE_PORT"
 
 if [[ "$TRAVIS_PULL_REQUEST" = "false" ]]; then
 	curl -s https://raw.githubusercontent.com/symphonyoss/contrib-toolbox/master/scripts/oc-deploy.sh | bash

--- a/after-success.sh
+++ b/after-success.sh
@@ -3,11 +3,15 @@
 BRANCH_NAME=$1
 TRAVIS_PULL_REQUEST=$2
 
+# NodePorts must be within 30000-32767 range - read more on https://docs.openshift.com/container-platform/latest/dev_guide/expose_service/expose_internal_ip_nodeport.html
+
 if [[ $BRANCH_NAME =~ master ]]; then
 	export SYMPHONY_POD_HOST="foundation.symphony.com"
 	export SYMPHONY_API_HOST="foundation-api.symphony.com"
     export BOT_NAME="votebot-prod"
     export OC_PROJECT_NAME="ssf-prod"
+    export OC_PROJECT_NAME="ssf-prod"
+    export JOLOKIA_NODE_PORT=30010
 
 elif [[ $BRANCH_NAME =~ develop ]]; then
 	# Reset Openshift env on every build, for testing purposes
@@ -16,6 +20,7 @@ elif [[ $BRANCH_NAME =~ develop ]]; then
 	export SYMPHONY_API_HOST="foundation-dev-api.symphony.com"
     export BOT_NAME="votebot-dev"
     export OC_PROJECT_NAME="ssf-dev"
+    export JOLOKIA_NODE_PORT=30011
 fi
 
 export OC_BINARY_FOLDER="vote-bot-service/target/oc"

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.symphonyoss.symphony</groupId>
             <artifactId>symphony-client</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.4</version>
         </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>
@@ -85,6 +85,17 @@
             <version>4.11</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.jolokia</groupId>
+            <artifactId>jolokia-jvm</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jolokia</groupId>
+            <artifactId>jolokia-jvm</artifactId>
+            <version>1.4.0</version>
+            <classifier>agent</classifier>
+        </dependency>
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,12 +88,12 @@
         <dependency>
             <groupId>org.jolokia</groupId>
             <artifactId>jolokia-jvm</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.jolokia</groupId>
             <artifactId>jolokia-jvm</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <classifier>agent</classifier>
         </dependency>
         <dependency>

--- a/vote-bot-service/src/main/java/org/symphonyoss/vb/VoteBot.java
+++ b/vote-bot-service/src/main/java/org/symphonyoss/vb/VoteBot.java
@@ -30,6 +30,10 @@ import org.eclipse.jetty.webapp.WebAppContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.symphonyoss.vb.config.BotConfig;
+import org.jolokia.jvmagent.JolokiaServer;
+import org.jolokia.jvmagent.JolokiaServerConfig;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Created by Frank on 9/4/2015.
@@ -84,8 +88,13 @@ public class VoteBot {
 
             server.join();
 
-
-
+            // Init Jolokja agent
+            Map<String, String> serverConfigMap = new HashMap<>();
+            // TODO - take it from SJC config
+            serverConfigMap.put("JOLOKIA_HOST","*");
+            JolokiaServerConfig serverConfig = new JolokiaServerConfig(serverConfigMap);
+            JolokiaServer jolokiaServer = new JolokiaServer(serverConfig, true);
+            jolokiaServer.start();
         } catch (Exception e) {
 
             e.printStackTrace();


### PR DESCRIPTION
The following changes allow to monitor the bot via JMX/Jolokia, simply invoking a URL on port 8778, see docs on https://github.com/symphonyoss/symphony-java-client#exposing-jmx-healthcheck-endpoint
